### PR TITLE
커스텀 모달 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import 'react-native-gesture-handler';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {RecoilRoot} from 'recoil';
+import CustomModal from './components/public/Modal';
 import {navigationRef} from './lib/utils/navigation-helper';
 import RootStackNavigator from './navigation/RootStackNavigator';
 
@@ -19,6 +20,7 @@ export default function App() {
           <SafeAreaProvider>
             <NavigationContainer ref={navigationRef}>
               <RootStackNavigator />
+              <CustomModal />
             </NavigationContainer>
           </SafeAreaProvider>
         </RecoilRoot>

--- a/src/components/public/Modal.tsx
+++ b/src/components/public/Modal.tsx
@@ -18,7 +18,7 @@ const CustomModal = () => {
     secondaryButtonText,
     onPrimaryButtonPress,
     onSecondaryButtonPress,
-    hideModal,
+    resetModal,
   } = useModal();
 
   const renderContent = () => {
@@ -82,7 +82,7 @@ const CustomModal = () => {
       animationType="fade"
       transparent
       visible={isVisible}
-      onRequestClose={hideModal}
+      onRequestClose={resetModal}
       statusBarTranslucent>
         <View style={styles.centeredView}>
           <View style={styles.modalView}>

--- a/src/components/public/Modal.tsx
+++ b/src/components/public/Modal.tsx
@@ -13,12 +13,30 @@ const CustomModal = () => {
   const {
     title,
     body,
+    singleMessage,
     primaryButtonText,
     secondaryButtonText,
     onPrimaryButtonPress,
     onSecondaryButtonPress,
     hideModal,
   } = useModal();
+
+  const renderContent = () => {
+    if (singleMessage) {
+      return <Text style={[typography.subTitle_02_M, styles.singleMessage]}>{singleMessage}</Text>;
+    }
+    
+    if (title && body) {
+      return (
+        <>
+          <Text style={[typography.subTitle_02, styles.title]}>{title}</Text>
+          <Text style={[typography.body_01_M, styles.body]}>{body}</Text>
+        </>
+      );
+    }
+    
+    return null;
+  };
 
   const renderButtons = () => {
     const buttonStyles = [styles.button];
@@ -69,10 +87,7 @@ const CustomModal = () => {
         <View style={styles.centeredView}>
           <View style={styles.modalView}>
             <View style={styles.textWrapper}>
-              <Text style={[typography.subTitle_02, styles.title]}>{title}</Text>
-              {body && (
-                <Text style={[typography.body_02, styles.body]}>{body}</Text>
-              )}
+              {renderContent()}
             </View>
             {renderButtons()}
           </View>
@@ -107,6 +122,10 @@ const styles = StyleSheet.create({
   body: {
     textAlign: 'center',
     color: COLORS.gray.Gray05,
+  },
+  singleMessage: {
+    textAlign: 'center',
+    color: COLORS.black,
   },
   button: {
     height: ms(48),

--- a/src/components/public/Modal.tsx
+++ b/src/components/public/Modal.tsx
@@ -61,8 +61,8 @@ const CustomModal = () => {
       case ModalType.TWO_BUTTONS:
         return (
           <View style={styles.twoButtonsContainer}>
-            {renderButton(secondaryButtonText || '', onSecondaryButtonPress, [styles.secondaryButton], styles.secondaryButtonText)}
-            {renderButton(primaryButtonText || '', onPrimaryButtonPress, [styles.primaryButton], styles.primaryButtonText)}
+            {renderButton(secondaryButtonText || '', onSecondaryButtonPress, [styles.secondaryButton, styles.flexButton], styles.secondaryButtonText)}
+            {renderButton(primaryButtonText || '', onPrimaryButtonPress, [styles.primaryButton, styles.flexButton], styles.primaryButtonText)}
           </View>
         );
       case ModalType.STACKED_BUTTONS:
@@ -149,10 +149,11 @@ const styles = StyleSheet.create({
   },
   primaryButton: {
     backgroundColor: COLORS.orange.Orange01,
-    flex: 1,
   },
   secondaryButton: {
     backgroundColor: COLORS.orange.Orange02,
+  },
+  flexButton: {
     flex: 1,
   },
   stackedButton: {

--- a/src/components/public/Modal.tsx
+++ b/src/components/public/Modal.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { Modal, StyleSheet, Text, TextStyle, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { useRecoilValue } from 'recoil';
+import useModal from '../../hooks/useModal';
+import { COLORS } from '../../lib/styles/theme';
+import { typography } from '../../lib/styles/typography';
+import { ms } from '../../lib/utils/dimensions';
+import { isModalVisibleSelector, ModalType, modalTypeSelector } from '../../stores/modal';
+
+const CustomModal = () => {
+  const isVisible = useRecoilValue(isModalVisibleSelector);
+  const modalType = useRecoilValue(modalTypeSelector);
+  const {
+    title,
+    body,
+    primaryButtonText,
+    secondaryButtonText,
+    onPrimaryButtonPress,
+    onSecondaryButtonPress,
+    hideModal,
+  } = useModal();
+
+  const renderButtons = () => {
+    const buttonStyles = [styles.button];
+    const textStyles = [typography.buttons_01];
+
+    const renderButton = (
+      text: string,
+      onPress: (() => void) | undefined,
+      additionalBtnStyles: ViewStyle[],
+      textStyle: TextStyle
+    ) => (
+      <TouchableOpacity
+        style={[...buttonStyles, ...additionalBtnStyles]}
+        onPress={onPress || (() => {})}>
+        <Text style={[...textStyles, textStyle]}>{text}</Text>
+      </TouchableOpacity>
+    );
+
+    switch (modalType) {
+      case ModalType.SINGLE_BUTTON:
+        return renderButton(primaryButtonText, onPrimaryButtonPress, [styles.singleButton], styles.primaryButtonText);
+      case ModalType.TWO_BUTTONS:
+        return (
+          <View style={styles.twoButtonsContainer}>
+            {renderButton(secondaryButtonText || '', onSecondaryButtonPress, [styles.secondaryButton], styles.secondaryButtonText)}
+            {renderButton(primaryButtonText || '', onPrimaryButtonPress, [styles.primaryButton], styles.primaryButtonText)}
+          </View>
+        );
+      case ModalType.STACKED_BUTTONS:
+        return (
+          <View style={styles.stackedButtonsContainer}>
+            {renderButton(primaryButtonText, onPrimaryButtonPress, [styles.primaryButton, styles.stackedButton], styles.primaryButtonText)}
+            {renderButton(secondaryButtonText || '', onSecondaryButtonPress, [styles.secondaryButton, styles.stackedButton], styles.secondaryButtonText)}
+          </View>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Modal
+      animationType="fade"
+      transparent
+      visible={isVisible}
+      onRequestClose={hideModal}
+      statusBarTranslucent>
+        <View style={styles.centeredView}>
+          <View style={styles.modalView}>
+            <View style={styles.textWrapper}>
+              <Text style={[typography.subTitle_02, styles.title]}>{title}</Text>
+              {body && (
+                <Text style={[typography.body_02, styles.body]}>{body}</Text>
+              )}
+            </View>
+            {renderButtons()}
+          </View>
+        </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+  },
+  modalView: {
+    width: ms(342),
+    backgroundColor: COLORS.white,
+    borderRadius: 12,
+    padding: ms(16),
+    paddingTop: ms(24),
+    alignItems: 'center',
+  },
+  textWrapper: {
+    marginBottom: ms(24),
+    gap: ms(8),
+  },
+  title: {
+    textAlign: 'center',
+    color: COLORS.black,
+  },
+  body: {
+    textAlign: 'center',
+    color: COLORS.gray.Gray05,
+  },
+  button: {
+    height: ms(48),
+    borderRadius: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  singleButton: {
+    backgroundColor: COLORS.orange.Orange01,
+    width: '100%',
+  },
+  twoButtonsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+    gap: ms(8),
+  },
+  stackedButtonsContainer: {
+    width: '100%',
+    gap: ms(12),
+  },
+  primaryButton: {
+    backgroundColor: COLORS.orange.Orange01,
+    flex: 1,
+  },
+  secondaryButton: {
+    backgroundColor: COLORS.orange.Orange02,
+    flex: 1,
+  },
+  stackedButton: {
+    width: '100%',
+  },
+  primaryButtonText: {
+    color: COLORS.white,
+  },
+  secondaryButtonText: {
+    color: COLORS.orange.Orange01,
+  },
+});
+
+export default CustomModal;

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -2,8 +2,10 @@ import { useRecoilState } from 'recoil';
 import {
   MODAL_CONFIGS,
   modalState,
+  ModalType,
   ScreenKeys,
-  ShowModalParams
+  ShowModalParams,
+  SingleMessageModalState
 } from '../stores/modal';
 
 const useModal = () => {
@@ -12,6 +14,7 @@ const useModal = () => {
   const showModal = <T extends ScreenKeys>({ screen, modalKey, customConfig = {} }: ShowModalParams<T>) => {
     const screenConfigs = MODAL_CONFIGS[screen];
     if (screenConfigs && modalKey in screenConfigs) {
+      resetModal();
       const baseConfig = screenConfigs[modalKey];
       setState(prevState => ({
         ...prevState,
@@ -26,9 +29,20 @@ const useModal = () => {
     setState(prev => ({...prev, isVisible: false}));
   };
 
+  const resetModal = () => {
+    setState({
+      isVisible: false,
+      primaryButtonText: '',
+      secondaryButtonText: '',
+      modalType: ModalType.NONE,
+      singleMessage: '',
+    } as SingleMessageModalState);
+  };
+
   return {
     showModal,
     hideModal,
+    resetModal,
     ...state,
   };
 };

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,36 @@
+import { useRecoilState } from 'recoil';
+import {
+  MODAL_CONFIGS,
+  modalState,
+  ScreenKeys,
+  ShowModalParams
+} from '../stores/modal';
+
+const useModal = () => {
+  const [state, setState] = useRecoilState(modalState);
+
+  const showModal = <T extends ScreenKeys>({ screen, modalKey, customConfig = {} }: ShowModalParams<T>) => {
+    const screenConfigs = MODAL_CONFIGS[screen];
+    if (screenConfigs && modalKey in screenConfigs) {
+      const baseConfig = screenConfigs[modalKey];
+      setState(prevState => ({
+        ...prevState,
+        ...baseConfig,
+        ...customConfig,
+        isVisible: true,
+      }));
+    }
+  };
+
+  const hideModal = () => {
+    setState(prev => ({...prev, isVisible: false}));
+  };
+
+  return {
+    showModal,
+    hideModal,
+    ...state,
+  };
+};
+
+export default useModal;

--- a/src/lib/styles/typography.ts
+++ b/src/lib/styles/typography.ts
@@ -1,5 +1,5 @@
-import {StyleSheet} from 'react-native';
-import {FONTFAMILY} from './theme';
+import { StyleSheet } from 'react-native';
+import { FONTFAMILY } from './theme';
 
 export const typography = StyleSheet.create({
   header: {
@@ -22,6 +22,11 @@ export const typography = StyleSheet.create({
     fontSize: 20,
     lineHeight: 20 * 1.3,
   },
+  subTitle_02_M: {
+    fontFamily: FONTFAMILY.pretendard_medium,
+    fontSize: 20,
+    lineHeight: 20 * 1.3,
+  },
   body_01: {
     fontFamily: FONTFAMILY.pretendard_regular,
     fontSize: 18,
@@ -29,6 +34,11 @@ export const typography = StyleSheet.create({
   },
   body_01_B: {
     fontFamily: FONTFAMILY.pretendard_bold,
+    fontSize: 18,
+    lineHeight: 18 * 1.3,
+  },
+  body_01_M: {
+    fontFamily: FONTFAMILY.pretendard_medium,
     fontSize: 18,
     lineHeight: 18 * 1.3,
   },

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -57,7 +57,7 @@ const HomeScreen = () => {
         onSecondaryButtonPress: () => {
           hideModal();
           console.log('지도로 이동');
-            // navigation.navigate('MapScreen');
+          // navigation.navigate('MapScreen');
         },
       },
     });

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,5 +1,5 @@
-import {BottomTabNavigationProp} from '@react-navigation/bottom-tabs';
-import {CompositeNavigationProp, useNavigation} from '@react-navigation/native';
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { CompositeNavigationProp, useNavigation } from '@react-navigation/native';
 import React from 'react';
 import {
   Pressable,
@@ -9,12 +9,13 @@ import {
   Text,
   View,
 } from 'react-native';
-import {COLORS, FONTFAMILY} from '../../lib/styles/theme';
-import {typography} from '../../lib/styles/typography';
+import { COLORS, FONTFAMILY } from '../../lib/styles/theme';
+import { typography } from '../../lib/styles/typography';
 
 import FastImage from 'react-native-fast-image';
 import RightIcon from '../../assets/svg/icon_right.svg';
-import {isIOS} from '../../lib/utils';
+import useModal from '../../hooks/useModal';
+import { isIOS } from '../../lib/utils';
 import {
   BASE_SAFEAREATOP,
   ms,
@@ -24,6 +25,7 @@ import {
   BottomTabParamList,
   MainStackNavigationProp,
 } from '../../navigation/types';
+import { HomeModalKeys, ScreenKeys } from '../../stores/modal';
 
 type HomeScreenNavigationProp = CompositeNavigationProp<
   MainStackNavigationProp,
@@ -32,6 +34,7 @@ type HomeScreenNavigationProp = CompositeNavigationProp<
 
 const HomeScreen = () => {
   const navigation = useNavigation<HomeScreenNavigationProp>();
+  const {showModal, hideModal} = useModal();
 
   const handleNavigateToLostItem = () => {
     navigation.navigate('LostItemStack', {screen: 'LostItemRegistration'});
@@ -42,7 +45,22 @@ const HomeScreen = () => {
   };
 
   const handleNavigateToMatchingList = () => {
-    navigation.navigate('MyPageTab', {screen: 'MatchingList'});
+    // 추후 분실물 등록 여부에 따라 모달 제어
+    showModal({
+      screen: ScreenKeys.HOME,
+      modalKey: HomeModalKeys.NO_LOST_ITEM,
+      customConfig: {
+        onPrimaryButtonPress: () => {
+          hideModal();
+          handleNavigateToLostItem();
+        },
+        onSecondaryButtonPress: () => {
+          hideModal();
+          console.log('지도로 이동');
+            // navigation.navigate('MapScreen');
+        },
+      },
+    });
   };
 
   return (

--- a/src/screens/lostItem/LostItemColorsScreen.tsx
+++ b/src/screens/lostItem/LostItemColorsScreen.tsx
@@ -1,5 +1,5 @@
-import {useNavigation} from '@react-navigation/native';
-import React, {useMemo, useState} from 'react';
+import { useNavigation } from '@react-navigation/native';
+import React, { useMemo, useState } from 'react';
 import {
   FlatList,
   Pressable,
@@ -8,17 +8,20 @@ import {
   Text,
   View,
 } from 'react-native';
-import {useRecoilState} from 'recoil';
-import {PrimaryLargeBtn} from '../../components/public/Buttons';
-import {CloseBtnGnbHeader} from '../../components/public/GnbHeader';
-import {COLORS} from '../../lib/styles/theme';
-import {typography} from '../../lib/styles/typography';
-import {bottomWithSafeArea, ms} from '../../lib/utils/dimensions';
-import {lostItemColorsAtom} from '../../stores/lostItem';
-import {COLOR_VALUES, ColorOption} from '../../stores/lostItem/types';
+import { useRecoilState } from 'recoil';
+import { PrimaryLargeBtn } from '../../components/public/Buttons';
+import { CloseBtnGnbHeader } from '../../components/public/GnbHeader';
+import useModal from '../../hooks/useModal';
+import { COLORS } from '../../lib/styles/theme';
+import { typography } from '../../lib/styles/typography';
+import { bottomWithSafeArea, ms } from '../../lib/utils/dimensions';
+import { lostItemColorsAtom } from '../../stores/lostItem';
+import { COLOR_VALUES, ColorOption } from '../../stores/lostItem/types';
+import { LostItemColorsModalKeys, ScreenKeys } from '../../stores/modal/configs';
 
 const LostItemColorsScreen = () => {
   const navigation = useNavigation();
+  const {showModal, hideModal} = useModal();
   const [colors, setColors] = useRecoilState(lostItemColorsAtom);
   const [selectedColors, setSelectedColors] = useState<ColorOption[]>(colors);
 
@@ -29,7 +32,25 @@ const LostItemColorsScreen = () => {
       if (prev.includes(color)) {
         return prev.filter(c => c !== color);
       } else if (color === ColorOption.OTHER) {
+        if (prev.length > 0 && !prev.includes(ColorOption.OTHER)) {
+          showModal({
+            screen: ScreenKeys.LOST_ITEM_COLORS,
+            modalKey: LostItemColorsModalKeys.OTHER_COLOR_SELECTED,
+            customConfig: {
+              onPrimaryButtonPress: hideModal,
+            },
+          });
+        }
         return [color];
+      } else if (prev.includes(ColorOption.OTHER)) {
+        showModal({
+          screen: ScreenKeys.LOST_ITEM_COLORS,
+          modalKey: LostItemColorsModalKeys.OTHER_COLOR_SELECTED,
+          customConfig: {
+            onPrimaryButtonPress: hideModal,
+          },
+        });
+        return prev;
       } else if (!prev.includes(ColorOption.OTHER) && prev.length < 2) {
         return [...prev, color];
       }

--- a/src/screens/lostItem/LostItemRegistrationScreen.tsx
+++ b/src/screens/lostItem/LostItemRegistrationScreen.tsx
@@ -64,8 +64,6 @@ const LostItemRegistrationScreen = () => {
   const handleGoBackWithResetState = useResetOnBackNavigation(resetLostItem);
 
   const validateRequiredFields = useCallback(() => {
-    if (!hasBeenChecked) return true;
-    
     const newErrors = {
       name: !lostItemName.trim(),
       category: !lostItemCategory.main,
@@ -74,15 +72,20 @@ const LostItemRegistrationScreen = () => {
     
     setErrors(newErrors);
     return Object.values(newErrors).every(error => !error);
-  }, [hasBeenChecked, lostItemName, lostItemCategory.main, lostItemColors]);
+  }, [lostItemName, lostItemCategory.main, lostItemColors]);
 
   useEffect(() => {
-    validateRequiredFields();
-  }, [validateRequiredFields]);
+    if (hasBeenChecked) {
+      validateRequiredFields();
+    }
+  }, [validateRequiredFields, hasBeenChecked]);
 
   const handleNavigateToMap = () => {
     setHasBeenChecked(true);
-    if (!validateRequiredFields()) return;
+    const isValid = validateRequiredFields();
+    
+    if (!isValid) return;
+
     if (
       lostItemCategory.main === MainCategory.NONE &&
       lostItemColors.includes(ColorOption.OTHER)
@@ -113,6 +116,11 @@ const LostItemRegistrationScreen = () => {
       }
     : null;
 
+  const handleNameChange = (text: string) => {
+    setLostItemName(text);
+    setErrors(prev => ({...prev, name: false}));
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <KeyboardAvoidingWrapper withMultiline={true}>
@@ -133,10 +141,7 @@ const LostItemRegistrationScreen = () => {
                   errors.name && styles.requiredField,
                 ]}
                 value={lostItemName}
-                onChangeText={text => {
-                  setLostItemName(text);
-                  setErrors(prev => ({...prev, name: false}));
-                }}
+                onChangeText={handleNameChange}
                 placeholder="물건 이름을 입력해주세요."
                 placeholderTextColor={COLORS.gray.Gray03}
               />

--- a/src/stores/modal/atoms.ts
+++ b/src/stores/modal/atoms.ts
@@ -1,13 +1,13 @@
 import { atom } from 'recoil';
 import { ModalType } from './configs';
-import { ModalState } from './types';
+import { ModalState, SingleMessageModalState } from './types';
 
 export const modalState = atom<ModalState>({
   key: 'modalState',
   default: {
     isVisible: false,
-    body: '',
     primaryButtonText: '',
     modalType: ModalType.NONE,
-  },
+    singleMessage: '',
+  } as SingleMessageModalState,
 });

--- a/src/stores/modal/atoms.ts
+++ b/src/stores/modal/atoms.ts
@@ -1,0 +1,13 @@
+import { atom } from 'recoil';
+import { ModalType } from './configs';
+import { ModalState } from './types';
+
+export const modalState = atom<ModalState>({
+  key: 'modalState',
+  default: {
+    isVisible: false,
+    body: '',
+    primaryButtonText: '',
+    modalType: ModalType.NONE,
+  },
+});

--- a/src/stores/modal/configs.ts
+++ b/src/stores/modal/configs.ts
@@ -1,0 +1,40 @@
+import { ModalConfigsType } from './';
+
+export enum ModalType {
+  NONE = 'NONE',
+  SINGLE_BUTTON = 'SINGLE_BUTTON',
+  TWO_BUTTONS = 'TWO_BUTTONS',
+  STACKED_BUTTONS = 'STACKED_BUTTONS',
+}
+
+export enum LostItemRegistrationModalKeys {
+  CONFIRMATION = 'CONFIRMATION',
+}
+
+export enum HomeModalKeys {}
+
+export enum ScreenKeys {
+  LOST_ITEM_REGISTRATION = 'LOST_ITEM_REGISTRATION',
+  HOME = 'HOME',
+  // 다른 스크린 키를 여기에 추가할 수 있습니다.
+}
+
+export const MODAL_CONFIGS: ModalConfigsType = {
+  [ScreenKeys.LOST_ITEM_REGISTRATION]: {
+    [LostItemRegistrationModalKeys.CONFIRMATION]: {
+      title: '이대로 등록할까요?',
+      body: '카테고리와 색상을 선택하지 않으면\n매칭 리스트를 확인할 수 없어요.',
+      primaryButtonText: '확인',
+      secondaryButtonText: '취소',
+      modalType: ModalType.TWO_BUTTONS,
+    },
+  },
+  [ScreenKeys.HOME]: {
+    // 홈스크린 등록 관련 모달 설정을 여기에 추가
+  },
+};
+
+export const ModalKeysByScreen = {
+  [ScreenKeys.LOST_ITEM_REGISTRATION]: LostItemRegistrationModalKeys,
+  [ScreenKeys.HOME]: HomeModalKeys,
+} as const;

--- a/src/stores/modal/configs.ts
+++ b/src/stores/modal/configs.ts
@@ -15,7 +15,9 @@ export enum LostItemColorsModalKeys {
   OTHER_COLOR_SELECTED = 'OTHER_COLOR_SELECTED',
 }
 
-export enum HomeModalKeys {}
+export enum HomeModalKeys {
+  NO_LOST_ITEM = 'NO_LOST_ITEM',
+}
 
 export enum ScreenKeys {
   LOST_ITEM_REGISTRATION = 'LOST_ITEM_REGISTRATION',
@@ -35,14 +37,18 @@ export const MODAL_CONFIGS: ModalConfigsType = {
   },
   [ScreenKeys.LOST_ITEM_COLORS]: {
     [LostItemColorsModalKeys.OTHER_COLOR_SELECTED]: {
-      title: '색상 선택',
-      body: '기타를 선택하면 다른 색상은\n선택할 수 없어요.',
+      singleMessage: '\'기타\'를 선택하면\n다른 색상을 선택할 수 없어요.',
       primaryButtonText: '확인',
       modalType: ModalType.SINGLE_BUTTON,
     },
   },
   [ScreenKeys.HOME]: {
-    // 홈스크린 등록 관련 모달 설정을 여기에 추가
+    [HomeModalKeys.NO_LOST_ITEM]: {
+      singleMessage: '아직 등록한 분실물이 없어요',
+      primaryButtonText: '분실물 등록하기',
+      secondaryButtonText: '근처 습득물 보러가기',
+      modalType: ModalType.STACKED_BUTTONS,
+    },
   },
 };
 

--- a/src/stores/modal/configs.ts
+++ b/src/stores/modal/configs.ts
@@ -11,12 +11,16 @@ export enum LostItemRegistrationModalKeys {
   CONFIRMATION = 'CONFIRMATION',
 }
 
+export enum LostItemColorsModalKeys {
+  OTHER_COLOR_SELECTED = 'OTHER_COLOR_SELECTED',
+}
+
 export enum HomeModalKeys {}
 
 export enum ScreenKeys {
   LOST_ITEM_REGISTRATION = 'LOST_ITEM_REGISTRATION',
   HOME = 'HOME',
-  // 다른 스크린 키를 여기에 추가할 수 있습니다.
+  LOST_ITEM_COLORS = 'LOST_ITEM_COLORS',
 }
 
 export const MODAL_CONFIGS: ModalConfigsType = {
@@ -29,6 +33,14 @@ export const MODAL_CONFIGS: ModalConfigsType = {
       modalType: ModalType.TWO_BUTTONS,
     },
   },
+  [ScreenKeys.LOST_ITEM_COLORS]: {
+    [LostItemColorsModalKeys.OTHER_COLOR_SELECTED]: {
+      title: '색상 선택',
+      body: '기타를 선택하면 다른 색상은\n선택할 수 없어요.',
+      primaryButtonText: '확인',
+      modalType: ModalType.SINGLE_BUTTON,
+    },
+  },
   [ScreenKeys.HOME]: {
     // 홈스크린 등록 관련 모달 설정을 여기에 추가
   },
@@ -37,4 +49,6 @@ export const MODAL_CONFIGS: ModalConfigsType = {
 export const ModalKeysByScreen = {
   [ScreenKeys.LOST_ITEM_REGISTRATION]: LostItemRegistrationModalKeys,
   [ScreenKeys.HOME]: HomeModalKeys,
+  [ScreenKeys.LOST_ITEM_COLORS]: LostItemColorsModalKeys,
 } as const;
+

--- a/src/stores/modal/index.ts
+++ b/src/stores/modal/index.ts
@@ -1,0 +1,4 @@
+export * from './atoms';
+export * from './configs';
+export * from './selectors';
+export * from './types';

--- a/src/stores/modal/selectors.ts
+++ b/src/stores/modal/selectors.ts
@@ -1,0 +1,18 @@
+import { selector } from "recoil";
+import { modalState } from "./atoms";
+
+export const isModalVisibleSelector = selector({
+  key: 'isModalVisibleSelector',
+  get: ({get}) => {
+    const modal = get(modalState);
+    return modal.isVisible;
+  },
+});
+
+export const modalTypeSelector = selector({
+  key: 'modalTypeSelector',
+  get: ({get}) => {
+    const modal = get(modalState);
+    return modal.modalType;
+  },
+});

--- a/src/stores/modal/types.ts
+++ b/src/stores/modal/types.ts
@@ -1,0 +1,26 @@
+import { ModalKeysByScreen, ModalType, ScreenKeys } from './configs';
+
+export interface ModalState {
+  isVisible: boolean;
+  title?: string;
+  body: string;
+  primaryButtonText: string;
+  secondaryButtonText?: string;
+  onPrimaryButtonPress?: () => void;
+  onSecondaryButtonPress?: () => void;
+  modalType: ModalType
+}
+
+export type ModalKeysByScreenType = typeof ModalKeysByScreen;
+
+export type ModalConfigsType = {
+  [K in ScreenKeys]: {
+    [P in keyof (typeof ModalKeysByScreen)[K]]: Omit<ModalState, 'isVisible' | 'onPrimaryButtonPress' | 'onSecondaryButtonPress'>;
+  };
+};
+
+export type ShowModalParams<T extends ScreenKeys> = {
+  screen: T;
+  modalKey: keyof ModalKeysByScreenType[T];
+  customConfig?: Partial<ModalState>;
+};

--- a/src/stores/modal/types.ts
+++ b/src/stores/modal/types.ts
@@ -1,15 +1,27 @@
 import { ModalKeysByScreen, ModalType, ScreenKeys } from './configs';
 
-export interface ModalState {
+type BaseModalState = {
   isVisible: boolean;
-  title?: string;
-  body: string;
   primaryButtonText: string;
   secondaryButtonText?: string;
   onPrimaryButtonPress?: () => void;
   onSecondaryButtonPress?: () => void;
-  modalType: ModalType
-}
+  modalType: ModalType;
+};
+
+export type SingleMessageModalState = BaseModalState & {
+  singleMessage: string;
+  title?: never;
+  body?: never;
+};
+
+type TitleBodyModalState = BaseModalState & {
+  singleMessage?: never;
+  title: string;
+  body: string;
+};
+
+export type ModalState = SingleMessageModalState | TitleBodyModalState;
 
 export type ModalKeysByScreenType = typeof ModalKeysByScreen;
 


### PR DESCRIPTION
## 📝작업 내용

- 커스텀 모달 기능 구현
   - useModal 커스텀훅으로 제어
   - stores/modal/configs.ts 파일에서 모달 설정 관리
   - 현재 홈스크린, 분실물 등록 스크린, 색상 선택 스크린까지 모달 등록 완료
- 분실물 등록 스크린 필수항목 누락시 로직 변경

## 💬리뷰 요구사항

새로운 스크린에서 사용할 모달 설정 순서 및 사용법

### src/stores/modal/configs.ts에 모달 설정
**1. 모달을 사용할 스크린을 ScreenKeys에 등록**
```typescript
export enum ScreenKeys {
  // 분실물 등록 스크린
  LOST_ITEM_REGISTRATION = 'LOST_ITEM_REGISTRATION',
  // 홈 스크린
  HOME = 'HOME',
  // 색상 선택 스크린
  LOST_ITEM_COLORS = 'LOST_ITEM_COLORS',
}
```

**2. 해당 스크린에서 사용할 모달들의 key를 모아서 enum으로 작성**
```typescript
export enum LostItemRegistrationModalKeys {
  // "해당없음"카테고리와 "기타"색상 선택 후 다음 버튼 클릭 시 나타나는 모달
  CONFIRMATION = 'CONFIRMATION',
}

export enum LostItemColorsModalKeys {
  // 기타와 다른 색상을 같이 고를 시 나타나는 모달
  OTHER_COLOR_SELECTED = 'OTHER_COLOR_SELECTED',
}

export enum HomeModalKeys {
  // 분실물 등록 안한 상태로 매칭리스트 버튼 클릭 시 나타나는 모달
  NO_LOST_ITEM = 'NO_LOST_ITEM',
}
```

**3. 모달 종류 구분 후 MODAL_CONFIGS 객체에 등록**
<p align="center">
  <img src="https://github.com/user-attachments/assets/5fa8484f-f26a-4742-9e7a-88d3fc86996a" width="30%" />
  <img src="https://github.com/user-attachments/assets/2114eb78-0a38-4cc1-9a05-65a427a4fe2d" width="30%" />
  <img src="https://github.com/user-attachments/assets/0dab4029-36a7-41b8-a32e-fc04b9376437" width="30%" />
</p>

- **모달 내부 content(텍스트)**
모달 내부 content 표시 방식이 두가지 텍스트(title&body)가 있는 것과 하나의 텍스트(singleMessage)만 있는 것, 두 종류가 있습니다.
- **모달 버튼 타입**
SINGLE_BUTTON 타입, TWO_BUTTONS 타입, STACKED_BUTTONS 타입, 총 3가지의 타입이 있습니다.

이에 따라 모달의 내부 content(title&body or singleMessage), 버튼 타입(modalType), 버튼 텍스트(primaryButtonText, secondaryButtonText) 등을 아래와 같은 형식으로 MODAL_CONFIGS 객체 내에 작성해주시면 됩니다.
> 이 때 각 버튼에 등록할 이벤트핸들러는 해당 스크린에서 useModal 커스텀 훅을 통해 전달하면 됩니다.
   
```typescript
export const MODAL_CONFIGS: ModalConfigsType = {
  [ScreenKeys.LOST_ITEM_REGISTRATION]: {
    [LostItemRegistrationModalKeys.CONFIRMATION]: {
      title: '이대로 등록할까요?',
      body: '카테고리와 색상을 선택하지 않으면\n매칭 리스트를 확인할 수 없어요.',
      primaryButtonText: '확인',
      secondaryButtonText: '취소',
      modalType: ModalType.TWO_BUTTONS,
    },
  },
  [ScreenKeys.LOST_ITEM_COLORS]: {
    [LostItemColorsModalKeys.OTHER_COLOR_SELECTED]: {
      singleMessage: '\'기타\'를 선택하면\n다른 색상을 선택할 수 없어요.',
      primaryButtonText: '확인',
      modalType: ModalType.SINGLE_BUTTON,
    },
  },
  [ScreenKeys.HOME]: {
    [HomeModalKeys.NO_LOST_ITEM]: {
      singleMessage: '아직 등록한 분실물이 없어요',
      primaryButtonText: '분실물 등록하기',
      secondaryButtonText: '근처 습득물 보러가기',
      modalType: ModalType.STACKED_BUTTONS,
    },
  },
};
```

### 스크린에서 조건에 따라 showModal()을 통해 모달 렌더링
이때 showModal에 전달해줄 인자는 3가지 입니다.
1. screen: 해당 모달을 사용할 스크린의 ScreenKey 전달
2. modalKey: 해당 모달의 ModalKey 전달
3. customConfig: 추가 설정 사항들 전달(각 버튼에 할당할 이벤트핸들러를 여기서 전달해주면 됩니다)

아래는 분실물 등록 스크린에서 모달을 사용한 예시입니다 :)
```typescript
const {showModal, hideModal} = useModal();

const handleNavigateToMap = () => {
   ...
    if (
      lostItemCategory.main === MainCategory.NONE &&
      lostItemColors.includes(ColorOption.OTHER)
    ) {
      showModal({
        screen: ScreenKeys.LOST_ITEM_REGISTRATION,
        modalKey: LostItemRegistrationModalKeys.CONFIRMATION,
        customConfig: {
          onPrimaryButtonPress: () => {
            console.log('지도로 이동');
            // navigation.navigate('MapScreen');
          },
          onSecondaryButtonPress: hideModal,
        },
      });
    } else {
      console.log('지도로 이동');
      // navigation.navigate('MapScreen');
    }
  };
```